### PR TITLE
Fixed soon-to-be deprecated sourceforge link

### DIFF
--- a/irbempy.html
+++ b/irbempy.html
@@ -1,4 +1,4 @@
-
+a
 <!DOCTYPE html>
 
 <html lang="en">
@@ -110,7 +110,7 @@
 <span id="irbempy-python-interface-to-irbem-library"></span><h1>irbempy - Python interface to IRBEM library<a class="headerlink" href="#module-spacepy.irbempy" title="Permalink to this heading">¶</a></h1>
 <p>module wrapper for irbem_lib
 Reference for this library
-<a class="reference external" href="https://sourceforge.net/projects/irbem/">https://sourceforge.net/projects/irbem/</a>
+<a class="reference external" href="https://github.com/PRBEM">https://github.com/PRBEM</a>
 D. Boscher, S. Bourdarie, P. O’Brien, T. Guild, IRBEM library V4.3, 2004-2008</p>
 <p>Most functions in this module use an options list to define the models used and the settings
 that define the quality level of the result. The options list is a 5-element list and is defined

--- a/spacepy.html
+++ b/spacepy.html
@@ -124,7 +124,7 @@ help available:</p>
 <td><p>Module with some useful empirical models (plasmapause, magnetopause, Lmax)</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="irbempy.html#module-spacepy.irbempy" title="spacepy.irbempy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">irbempy</span></code></a></p></td>
-<td><p>module wrapper for irbem_lib Reference for this library <a class="reference external" href="https://sourceforge.net/projects/irbem/">https://sourceforge.net/projects/irbem/</a> D.</p></td>
+<td><p>module wrapper for irbem_lib Reference for this library <a class="reference external" href="https://github.com/PRBEM">https://github.com/PRBEM</a> D.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="lanlstar.html#module-spacepy.LANLstar" title="spacepy.LANLstar"><code class="xref py py-obj docutils literal notranslate"><span class="pre">LANLstar</span></code></a></p></td>
 <td><p>Lstar and Lmax calculation using artificial neural network (ANN) technique.</p></td>


### PR DESCRIPTION
IRBEM-LIB has deprecated their sourceforge page, which the site currently links to. I updated the link on this page to go to the github for IRBEM (https://github.com/PRBEM)

closes spacepy issue 747 (https://github.com/spacepy/spacepy/issues/747)